### PR TITLE
Fix advanced notice validation

### DIFF
--- a/update/sys_script_9373668d4fd93200cb281b818110c7f9.xml
+++ b/update/sys_script_9373668d4fd93200cb281b818110c7f9.xml
@@ -29,26 +29,39 @@
         <role_conditions/>
         <script><![CDATA[(function executeRule(current, previous /*null when async*/) {
 	
-	// Instantiate the NeedItUtils class.  Call the isDatePast method and pass
-	// the u_when_needed value.
-	var niutils = new NeedItUtils();
-	var isPast = niutils.isDatePast(current.u_when_needed);
+        // Instantiate the NeedItUtils class.  Call the isDatePast method and pass
+        // the u_when_needed value.
+        var niutils = new NeedItUtils();
+        var isPast = niutils.isDatePast(current.u_when_needed);
 	
 	// If the isDatePast method returns true, the date is in the past.
 	if(isPast == true){
 		gs.addErrorMessage("When needed date cannot be in the past.  Your request has not been saved to the database.");
 		current.setAbortAction(true);
-	}
-	
-	
-	// pass the When needed field value to the isDateToday method in NeedItUtils
-	var isToday = niutils.isDateToday(current.u_when_needed);
-	
-	// if the isDateToday method returns true the When needed date is today 
-	if(isToday == true){
-		gs.addErrorMessage("You cannot submit NeedIt requests for today.");
-		current.setAbortAction(true);
-	}
+        }
+
+
+        // pass the When needed field value to the isDateToday method in NeedItUtils
+        var isToday = niutils.isDateToday(current.u_when_needed);
+
+        // if the isDateToday method returns true the When needed date is today
+        if(isToday == true){
+                gs.addErrorMessage("You cannot submit NeedIt requests for today.");
+                current.setAbortAction(true);
+        }
+
+        // Enforce advanced notice period if configured
+        var advanceNotice = parseInt(gs.getProperty('x_58872_needit.advancedNoticeDays', '0'), 10);
+        if(advanceNotice > 0){
+                var now = new GlideDateTime();
+                var minAllowed = new GlideDateTime(now);
+                minAllowed.addDaysLocalTime(advanceNotice);
+                var whenNeeded = new GlideDateTime(current.u_when_needed);
+                if(whenNeeded.before(minAllowed)){
+                        gs.addErrorMessage('When needed date must be at least ' + advanceNotice + ' days in the future.');
+                        current.setAbortAction(true);
+                }
+        }
 	
 })(current, previous);]]></script>
         <sys_class_name>sys_script</sys_class_name>


### PR DESCRIPTION
## Summary
- enforce the configured advanced notice days when validating NeedIt requests

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68699264b4008323b59d331392609c67